### PR TITLE
Add Google Analytics tag gated by cookie consent

### DIFF
--- a/_includes/base.njk
+++ b/_includes/base.njk
@@ -62,6 +62,12 @@
     <link rel="stylesheet" href="/assets/css/home.css">
     <link rel="stylesheet" href="/css/style.css">
     <link rel="stylesheet" href="/assets/css/glass.css">
+    <!-- Google tag (gtag.js) -->
+    <script data-gtag data-gtag-src="https://www.googletagmanager.com/gtag/js?id=G-N83YF635W2"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag() { dataLayer.push(arguments); }
+    </script>
     {% if headExtra %}{{ headExtra | safe }}{% endif %}
 </head>
 <body>
@@ -73,8 +79,11 @@
 
 {% include "footer.html" %}
 
-    
+{% include "cookie-consent.html" %}
+
+
     <!-- Any global scripts can go here -->
+    <script src="/assets/js/cookie-consent.js" defer></script>
 </body>
 {% include "bg-orbs.html" %}
 </html>

--- a/_includes/cookie-consent.html
+++ b/_includes/cookie-consent.html
@@ -1,0 +1,14 @@
+<div class="cookie-consent" data-cookie-consent hidden>
+  <div class="cookie-consent__inner" role="dialog" aria-live="polite" aria-modal="true" aria-label="Cookie consent">
+    <p class="cookie-consent__message">
+      We use cookies to understand how Daily Pick is used so we can keep improving the experience. May we enable analytics?
+    </p>
+    <div class="cookie-consent__actions" role="group" aria-label="Cookie consent actions">
+      <button class="btn btn--accent" type="button" data-cookie-accept>Allow analytics</button>
+      <button class="btn btn--secondary" type="button" data-cookie-decline>Decline</button>
+    </div>
+    <p class="cookie-consent__note">
+      You can update your choice anytime by clearing your browser cookies for this site.
+    </p>
+  </div>
+</div>

--- a/assets/css/home.css
+++ b/assets/css/home.css
@@ -119,6 +119,19 @@ body {
   transform: translateY(-2px);
 }
 
+.btn--secondary {
+  background-color: var(--gray-100);
+  color: var(--gray-700);
+  font-weight: 600;
+  border: 1px solid var(--gray-200);
+}
+
+.btn--secondary:hover,
+.btn--secondary:focus-visible {
+  background-color: #fff;
+  transform: translateY(-2px);
+}
+
 /* Hero */
 .hero {
   text-align: center;

--- a/assets/css/theme.css
+++ b/assets/css/theme.css
@@ -262,3 +262,89 @@ body {
     justify-content: center;
   }
 }
+
+.cookie-consent {
+  position: fixed;
+  inset-inline: 0;
+  bottom: 24px;
+  display: flex;
+  justify-content: center;
+  padding: 0 16px;
+  z-index: 1000;
+  opacity: 0;
+  transform: translateY(16px);
+  transition: opacity 0.3s ease, transform 0.3s ease;
+}
+
+.cookie-consent[hidden] {
+  display: none;
+}
+
+.cookie-consent.cookie-consent--visible {
+  opacity: 1;
+  transform: translateY(0);
+  pointer-events: auto;
+}
+
+.cookie-consent__inner {
+  background: var(--brand-surface);
+  border-radius: calc(var(--brand-radius) - 4px);
+  box-shadow: 0 18px 45px rgba(0, 0, 0, 0.15);
+  border: 1px solid rgba(52, 152, 219, 0.16);
+  max-width: 520px;
+  width: 100%;
+  padding: 20px 24px;
+  pointer-events: auto;
+}
+
+.cookie-consent__message {
+  margin: 0 0 16px;
+  font-size: 1rem;
+  line-height: 1.5;
+}
+
+.cookie-consent__actions {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.cookie-consent__actions .btn {
+  flex: 1 1 auto;
+  min-width: 140px;
+}
+
+.cookie-consent__note {
+  margin: 16px 0 0;
+  font-size: 0.85rem;
+  color: var(--brand-subtle-text);
+}
+
+.cookie-consent__note a {
+  color: var(--brand-accent-strong);
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.cookie-consent__note a:hover,
+.cookie-consent__note a:focus-visible {
+  text-decoration: underline;
+}
+
+@media (max-width: 480px) {
+  .cookie-consent {
+    bottom: 12px;
+  }
+
+  .cookie-consent__inner {
+    padding: 16px 18px;
+  }
+
+  .cookie-consent__actions {
+    flex-direction: column;
+  }
+
+  .cookie-consent__actions .btn {
+    width: 100%;
+  }
+}

--- a/assets/js/cookie-consent.js
+++ b/assets/js/cookie-consent.js
@@ -1,0 +1,108 @@
+const GTAG_ID = "G-N83YF635W2";
+const CONSENT_KEY = "dailyPickCookieConsent";
+
+function loadGoogleTag() {
+  if (window.gtagInitialized) {
+    return;
+  }
+
+  const existingScript = document.querySelector("script[data-gtag]");
+  if (existingScript) {
+    const currentSrc = existingScript.getAttribute("src");
+    if (!currentSrc) {
+      const dataSrc = existingScript.dataset.gtagSrc || `https://www.googletagmanager.com/gtag/js?id=${GTAG_ID}`;
+      existingScript.src = dataSrc;
+    } else if (!currentSrc.includes(GTAG_ID)) {
+      existingScript.src = `https://www.googletagmanager.com/gtag/js?id=${GTAG_ID}`;
+    }
+  }
+
+  if (!existingScript || !existingScript.getAttribute("src")) {
+    const gtagScript = document.createElement("script");
+    gtagScript.async = true;
+    gtagScript.src = `https://www.googletagmanager.com/gtag/js?id=${GTAG_ID}`;
+    gtagScript.setAttribute("data-gtag", "");
+    gtagScript.dataset.gtagSrc = `https://www.googletagmanager.com/gtag/js?id=${GTAG_ID}`;
+    document.head.appendChild(gtagScript);
+  }
+
+  window.dataLayer = window.dataLayer || [];
+  window.gtag = window.gtag || function gtag() {
+    window.dataLayer.push(arguments);
+  };
+
+  window.gtag("js", new Date());
+  window.gtag("config", GTAG_ID);
+  window.gtagInitialized = true;
+}
+
+function hideBanner(banner) {
+  if (!banner) return;
+  banner.setAttribute("hidden", "");
+  banner.classList.remove("cookie-consent--visible");
+}
+
+function showBanner(banner) {
+  if (!banner) return;
+  banner.classList.add("cookie-consent--visible");
+  banner.removeAttribute("hidden");
+}
+
+function storeConsent(value) {
+  try {
+    localStorage.setItem(CONSENT_KEY, value);
+  } catch (error) {
+    console.warn("Unable to store cookie consent preference", error);
+  }
+}
+
+function getStoredConsent() {
+  try {
+    return localStorage.getItem(CONSENT_KEY);
+  } catch (error) {
+    console.warn("Unable to read cookie consent preference", error);
+    return null;
+  }
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+  const banner = document.querySelector("[data-cookie-consent]");
+  if (!banner) {
+    if (getStoredConsent() === "granted") {
+      loadGoogleTag();
+    }
+    return;
+  }
+
+  const acceptBtn = banner.querySelector("[data-cookie-accept]");
+  const declineBtn = banner.querySelector("[data-cookie-decline]");
+  const existingConsent = getStoredConsent();
+
+  if (existingConsent === "granted") {
+    loadGoogleTag();
+    hideBanner(banner);
+    return;
+  }
+
+  if (existingConsent === "denied") {
+    hideBanner(banner);
+    return;
+  }
+
+  showBanner(banner);
+
+  if (acceptBtn) {
+    acceptBtn.addEventListener("click", () => {
+      storeConsent("granted");
+      loadGoogleTag();
+      hideBanner(banner);
+    });
+  }
+
+  if (declineBtn) {
+    declineBtn.addEventListener("click", () => {
+      storeConsent("denied");
+      hideBanner(banner);
+    });
+  }
+});

--- a/index.html
+++ b/index.html
@@ -37,6 +37,13 @@
     <meta name="msapplication-TileColor" content="#2d89ef">
     <meta name="theme-color" content="#ffffff">
 
+    <!-- Google tag (gtag.js) -->
+    <script data-gtag data-gtag-src="https://www.googletagmanager.com/gtag/js?id=G-N83YF635W2"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag() { dataLayer.push(arguments); }
+    </script>
+
     <!-- Fonts (performance) -->
     <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin>
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -217,7 +224,10 @@
     </main>
     {% include "footer.html" %}
 
+    {% include "cookie-consent.html" %}
+
     <!-- JS -->
+    <script src="/assets/js/cookie-consent.js" defer></script>
     <script src="/assets/js/home.js" type="module" defer></script>
 </body>
 


### PR DESCRIPTION
## Summary
- add the Google tag snippet to the global and home page head sections
- create a reusable cookie consent banner include with supporting styles
- initialize analytics only after the user accepts tracking and remember their choice

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68fee30628d48332a753fe16a0be0a22