### PR TITLE
Adjust sitemap lastmod for blog posts

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,3 +1,5 @@
+const fs = require("fs");
+const path = require("path");
 const sitemap = require("@quasibit/eleventy-plugin-sitemap");
 
 module.exports = function(eleventyConfig) {
@@ -56,6 +58,13 @@ module.exports = function(eleventyConfig) {
       } else if (item.inputPath.startsWith('./content/blog/posts/')) {
         item.data.sitemap.changefreq = 'weekly';
         item.data.sitemap.priority = 0.8;
+
+        const absolutePath = path.resolve(
+          process.cwd(),
+          item.inputPath.replace(/^\.\//, '')
+        );
+        const stats = fs.statSync(absolutePath);
+        item.data.sitemap.lastmod = stats.mtime;
       } else {
         item.data.sitemap.changefreq = 'monthly';
         item.data.sitemap.priority = 0.5;


### PR DESCRIPTION
## Summary
- update the Eleventy sitemap collection to compute blog post lastmod values from the Markdown file modification time
- ensure the sitemap plugin emits current lastmod dates when blog posts are edited

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_69023591806c8332b4a8cc9a3a9810cb